### PR TITLE
Change unit vh -> %

### DIFF
--- a/playground/tsunomakijanken/assets/scss/partials/_base.scss
+++ b/playground/tsunomakijanken/assets/scss/partials/_base.scss
@@ -4,7 +4,7 @@ html, body
     position: relative;
     width: 100vw;
     height: 100%;
-    min-height: 100vh;
+    min-height: 100%;
 
     background-color: #000; //#00325b;
     overflow: hidden;


### PR DESCRIPTION
100vh has a problem that the height of the address bar be included in the sum on Google Chrome for iOS.

e.g: https://heppokofrontend.github.io/css/100vh/
